### PR TITLE
feat: add flexible parameter override system with JSON configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,17 @@
 {
   "nodes": {
+    "claude-params": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
+        "type": "file",
+        "url": "file:///dev/null"
+      },
+      "original": {
+        "type": "file",
+        "url": "file:///dev/null"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +48,7 @@
     },
     "root": {
       "inputs": {
+        "claude-params": "claude-params",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/pkgs/claude-desktop.nix
+++ b/pkgs/claude-desktop.nix
@@ -10,14 +10,19 @@
   makeDesktopItem,
   makeWrapper,
   patchy-cnb,
-  perl
+  perl,
+  # Allow overriding Claude executable parameters
+  claudeHash ? "sha256-ISyVjtr9vGzCqq7oaDQd6h9kC7iumyo38z9VjuVCsu4=",
+  claudeVersion ? "0.12.129",
+  claudeUrl ? "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe"
 }: let
   pname = "claude-desktop";
-  version = "0.12.129";
+  version = claudeVersion;
   srcExe = fetchurl {
-    # NOTE: `?v=0.10.0` doesn't actually request a specific version. It's only being used here as a cache buster.
-    url = "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.exe?v=${version}";
-    hash = "sha256-ISyVjtr9vGzCqq7oaDQd6h9kC7iumyo38z9VjuVCsu4=";
+    # Use the provided URL and version, or defaults
+    url = "${claudeUrl}?v=${version}";
+    # Hash can be overridden via flake input
+    hash = claudeHash;
   };
 in
   stdenvNoCC.mkDerivation rec {


### PR DESCRIPTION
- Add support for overriding claudeHash, claudeVersion, and claudeUrl via JSON input
- Consolidate parameters into single claude-params input file
- Maintain single source of truth for defaults in package definition
- Support fallback to defaults when no parameters provided
- Enable easy local customization without upstream dependency